### PR TITLE
Transpiling expressions done

### DIFF
--- a/Graphite/Transpiler.cs
+++ b/Graphite/Transpiler.cs
@@ -113,19 +113,19 @@ public class Transpiler :
         var left = expression.left.Accept(this);
         var right = expression.right.Accept(this);
         
-        var @operator = expression.@operator.lexeme switch
+        var @operator = expression.@operator.type switch
         {
-            "==" => "==",
-            "!=" => "!=",
-            ">" => ">",
-            ">=" => ">=",
-            "<" => "<",
-            "<=" => "<=",
-            "+" => "+",
-            "-" => "-",
-            "*" => "*",
-            "/" => "/",
-            "mod" => "%",
+            TokenType.EQUAL_EQUAL => "==",
+            TokenType.BANG_EQUAL => "!=",
+            TokenType.GREATER => ">",
+            TokenType.GREATER_EQUAL => ">=",
+            TokenType.LESS => "<",
+            TokenType.LESS_EQUAL => "<=",
+            TokenType.PLUS => "+",
+            TokenType.MINUS => "-",
+            TokenType.STAR => "*",
+            TokenType.SLASH => "/",
+            TokenType.MOD => "%",
             _ => throw new Exception("Invalid operator")
         };
         
@@ -147,10 +147,10 @@ public class Transpiler :
     {
         var right = expression.right.Accept(this);
 
-        var @operator = expression.@operator.lexeme switch
+        var @operator = expression.@operator.type switch
         {
-            "-" => "-",
-            "!" => "!",
+            TokenType.MINUS => "-",
+            TokenType.BANG => "!",
             _ => throw new Exception("Invalid operator")
         };
 
@@ -174,10 +174,10 @@ public class Transpiler :
         var left = expression.left.Accept(this);
         var right = expression.right.Accept(this);
 
-        var @operator = expression.@operator.lexeme switch
+        var @operator = expression.@operator.type switch
         {
-            "and" => "&&",
-            "or" => "||",
+            TokenType.AND => "&&",
+            TokenType.OR => "||",
             _ => throw new Exception("Invalid operator")
         };
 


### PR DESCRIPTION
List and Set objects are transpiled using [] brackets. Could also be done using {} brackets.

That is because we can initialize a List/Set in two different ways:

List<int> ex = new() { 1, 2, 3 };     // with curly braces
List<int> ex3 = [ 1, 2, 3 ];              // with square braces

var ex2 = new List<int> { 1, 2, 3 }; // we are strongly typed so var doesn't make sense